### PR TITLE
[JDK-8358568] Fix crash caused by -XX:-GenerateSynchronizationCode

### DIFF
--- a/hotspot/src/share/vm/opto/locknode.cpp
+++ b/hotspot/src/share/vm/opto/locknode.cpp
@@ -198,7 +198,8 @@ void Parse::do_monitor_enter() {
 //------------------------------do_monitor_exit--------------------------------
 void Parse::do_monitor_exit() {
   kill_dead_locals();
-
+  if( !GenerateSynchronizationCode )
+    return;
   pop();                        // Pop oop to unlock
   // Because monitors are guaranteed paired (else we bail out), we know
   // the matching Lock for this Unlock.  Hence we know there is no need


### PR DESCRIPTION
This PR fixes JDK-8358568, a JVM crash triggered when running with -XX:-GenerateSynchronizationCode

Problem：
When synchronization code generation is disabled by  -XX:-GenerateSynchronizationCode, the compiler’s do_monitor_exit() method still tries to access monitor objects without checking if any monitors exist.This causes an assertion failure and JVM crash.

Root Cause：
Parse::do_monitor_exit() calls shared_unlock() using monitor info unconditionally,but with GenerateSynchronizationCode disabled, no monitor info is available, leading to invalid access.

Fix
Add a check in do_monitor_exit() to skip monitor unlocking if GenerateSynchronizationCode is false, avoiding invalid monitor access and preventing the crash.